### PR TITLE
Adding Subgroup Selector Functionality for Text Channels - V2

### DIFF
--- a/src/context/group-context.tsx
+++ b/src/context/group-context.tsx
@@ -15,6 +15,7 @@ type Member = {
 
 interface GroupContextType {
     selectedGroup: string
+    // Defines the user selected text channel. User can be part of a text channel as well as a voice channel.
     selectedTextChannel: string
     selectedVoiceChannel: string | null,
     setSelectedVoiceChannel: () => void,
@@ -70,7 +71,7 @@ export const GroupProvider = ({children}) => {
     const [selectedGroup, setSelectedGroup] = useState(
         {groupId: "control-center", groupName: "control-center"});
 
-    const [selectedTextChannel, setselectedTextChannel] = useState("general");
+    const [selectedTextChannel, setSelectedTextChannel] = useState("general");
 
     const callHookStates = useCall(selectedGroup)
     const [members, setMembers] = useState([])
@@ -96,7 +97,7 @@ export const GroupProvider = ({children}) => {
             selectedGroup: selectedGroup,
             setSelectedGroup: setSelectedGroup,
             selectedTextChannel: selectedTextChannel,
-            setselectedTextChannel: setselectedTextChannel,
+            setSelectedTextChannel: setSelectedTextChannel,
             members: members,
             setMembers: setMembers,
             ...callHookStates

--- a/src/pages/Groups/MessageArea.jsx
+++ b/src/pages/Groups/MessageArea.jsx
@@ -88,7 +88,7 @@ const MessageArea = () => {
                 <VideoPlayer /> :
 
         <div className="messageArea">
-            <header># general</header>
+            <header># {selectedTextChannel}</header>
             <div className="text-area">
                 <div ref={ref}><li>top</li></div>
                 {messages.map((msg) => {

--- a/src/pages/Groups/SubGroupSelector.jsx
+++ b/src/pages/Groups/SubGroupSelector.jsx
@@ -17,12 +17,12 @@ const SubGroupSelector = () => {
     const [show, setShow] = React.useState(false);
     const target = React.useRef(null);
     const [createModal, setCreateModal] = React.useState(false);
-    const {channelUsersMap} = useContext(GroupContext);
+    const {channelUsersMap, setSelectedTextChannel, selectedGroup} = useContext(GroupContext);
 
     return (
         <div className="subGroupSelector">
             <h4 className="groupTitle">
-                rox's server
+                {selectedGroup.groupName}
                 <span
                     ref={target}
                     onClick={() =>
@@ -65,7 +65,7 @@ const SubGroupSelector = () => {
                         <p>Some text in the Modal..</p>
                     </Modal>
                 </div>
-                <div className="channel">
+                <div className="channel" onClick={() => { setSelectedTextChannel("general") }}>
                     <h1>#</h1>
                     <h6>general</h6>
                     <OverlayTrigger
@@ -78,7 +78,7 @@ const SubGroupSelector = () => {
                         <button>*</button>
                     </OverlayTrigger>
                 </div>
-                <div className="channel">
+                <div className="channel" onClick={() => { setSelectedTextChannel("plans") }}>
                     <h1>#</h1>
                     <h6>plans</h6>
                     <OverlayTrigger


### PR DESCRIPTION
Purpose:
Currently the frontend is not able to switch between different text channels. Now, when you click a different text channel in any group, it is able to update the text channel name, as well as load in the messages for the respective channel.

Changes:

    Added onclick to switch the text channel in the group-context.
    Modified the text channel title to match the selected text channel state
    Modified the group title to match the selected group name state

