### PR TITLE
added a promise to check if anyone is still speaking & break

### DIFF
--- a/src/components/CallContainer.tsx
+++ b/src/components/CallContainer.tsx
@@ -86,11 +86,20 @@ const CallContainer = () => {
     });
 
     useClientEvent(client, "volume-indicator", volumes => {
-        console.log("this user's volume", currentUserUid)
-        volumes.forEach(volume => {
-            console.log("uid", volume.uid, "level", volume.level)
-            if (volume.level > 40) {
-                setSpeakerUid(volume.uid)
+        let isAnyoneSpeaking = false
+        const speakerPromise  = () => new Promise((res, rej) => {
+            volumes.forEach(volume => {
+                if (volume.level > 40) {
+                    setSpeakerUid(volume.uid)
+                    res(true)
+                }
+            })
+            res(false)
+        })
+
+        speakerPromise().then(isAnyoneSpeaking => {
+            if (!isAnyoneSpeaking) {
+                setSpeakerUid(null)
             }
         })
     })

--- a/src/context/group-context.tsx
+++ b/src/context/group-context.tsx
@@ -32,7 +32,7 @@ interface GroupContextType {
     agoraConfig: any
     setAgoraConfig: () => {}
     speakerUid: number | null
-    setSpeakerUid: (uid: UID) => {}
+    setSpeakerUid: (uid: UID | null) => {}
     currentUserUid: number | null
     setCurrentUserUid: (uid: UID) => {}
 }


### PR DESCRIPTION
There is a promise now that goes through all of the volumes. If it is higher than a certain amount, the agora uid of that user will be set to the state. 

However, the new functionality that has been added is if no one is speaking after the last person spoke, the last person's indicator will turn off instead of remaining on until the next person speaks.

Also, since the promise is being resolved as soon as the speaker is found, the loop ends there, so it increases efficiency on switch times.