### PR TITLE
voice call is now available in all pages

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -17,6 +17,7 @@ import AgoraRTC, {AgoraRTCProvider, useRTCClient} from "agora-rtc-react";
 import {GroupProvider} from "./context/group-context.tsx";
 import NotificationSocket from "./sockets/notifications.js";
 import {getGroups} from "./api/withToken.js";
+import CallContainer from "./components/CallContainer.tsx";
 
 
 function App() {
@@ -81,6 +82,7 @@ function App() {
             }}>
                 <AgoraRTCProvider client={client}>
                     <GroupProvider>
+                        <CallContainer />
                         <div className="App">{routes}</div>
                     </GroupProvider>
                 </AgoraRTCProvider>

--- a/src/components/NavBar.jsx
+++ b/src/components/NavBar.jsx
@@ -70,7 +70,6 @@ const NavBar = () => {
 
     return (
         <div className="navbar">
-            <CallContainer />
             <div className="logo2">
                 <div className="logo-wrapper">
                     <img

--- a/src/pages/Feed/index.jsx
+++ b/src/pages/Feed/index.jsx
@@ -13,7 +13,6 @@ const Feed = () => {
     return (
     // <div className={showComments ? "feed-container-show" : "feed-container"}>
         <div className={`feed-container ${showComments ? 'feed-container-show' : ''}`}>
-            <CallContainer />
         <div className="left-panel">
             <h3>Preferences</h3>
             <div className="checkbox-wrapper-3">


### PR DESCRIPTION
I thought this had been done already, but upon further testing it seems like voice call stops when going to a different page. However, with this change, voice call will continue no matter which page you are on. This actually also takes care of video. Going to another page will not disrupt the video feed either.