### PR TITLE
Adding channelId to text channels sockets to allow for messages to route to the right text channel

### DIFF
--- a/src/pages/Groups/GroupSelector.jsx
+++ b/src/pages/Groups/GroupSelector.jsx
@@ -32,7 +32,7 @@ const GroupSelector = () => {
     const groupClickHandler = (event) => {
         window.history.replaceState({}, document.title)
         groupControl.setSelectedGroup({groupId: event.target.id, groupName: event.target.getAttribute("data-name")});
-        chatsSocketApi.joinRoom(event.target.id)
+        chatsSocketApi.joinRoom(event.target.id, "general")
     };
 
     return (

--- a/src/pages/Groups/TextChannel.jsx
+++ b/src/pages/Groups/TextChannel.jsx
@@ -2,15 +2,13 @@ import OverlayTrigger from "react-bootstrap/OverlayTrigger";
 import Tooltip from "react-bootstrap/Tooltip";
 import React, {useContext, useEffect, useState} from "react";
 import {GroupContext} from "../../context/group-context.tsx";
+import {SocketContext} from "../../context/friends-socket-context";
 
 
 const TextChannel = ({channelName}) => {
-    const {showVideoView, selectedTextChannel, setSelectedTextChannel, setShowVideoView} = useContext(GroupContext);
+    const {showVideoView, selectedTextChannel, setSelectedTextChannel, setShowVideoView, selectedGroup} = useContext(GroupContext);
     const [channelStyle, setChannelStyle] = React.useState("channel inactive");
-
-    useEffect(() => {
-
-    }, [showVideoView]);
+    const { chatsSocketApi } = useContext(SocketContext)
 
     useEffect(() => {
         if (showVideoView){
@@ -23,6 +21,10 @@ const TextChannel = ({channelName}) => {
             }
         }
     }, [selectedTextChannel, showVideoView])
+    
+    useEffect(() => {
+        chatsSocketApi.joinRoom(selectedGroup.groupId, selectedTextChannel)
+    }, [selectedTextChannel])
 
     return (
         <div className={channelStyle} onClick={() => {

--- a/src/sockets/chat.js
+++ b/src/sockets/chat.js
@@ -42,9 +42,9 @@ class ChatSocket {
         this.socket.on('disconnectCallListener', callback)
     }
 
-    joinRoom(groupId) {
-        console.log("injoinroom15")
-        this.socket.emit("joinRoom", groupId)
+    joinRoom(groupId, channelName) {
+        console.log("injoinroom15", groupId, channelName)
+        this.socket.emit("joinRoom", groupId, channelName)
     }
 
 


### PR DESCRIPTION
Changes:
- Adding default channel to the initial group text channel socket connection
- Adding channelName parameter to joinRoom listeners to allow users to join group based on channelName